### PR TITLE
Migrate MailDev built from the latest code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,20 @@ RUN apk update && \
     nodejs \
     npm
 
+# install temporary packages
+RUN apk add --no-cache --virtual .temp-pkgs \
+    git \
+    python2 \
+    make \
+    g++
+
+WORKDIR ${APP_ROOT}
+
 # MailDev
-RUN npm install -g maildev
+RUN git clone https://github.com/maildev/maildev.git && \
+    cd maildev && \
+    npm ci --python=python2.7 && \
+    ln -fs ${APP_ROOT}/maildev/bin/maildev /usr/local/bin/maildev
 
 # sendgrid-dev
 RUN curl -L -o /usr/local/bin/sendgrid-dev https://github.com/yKanazawa/sendgrid-dev/releases/download/v0.9.0/sendgrid-dev_$(if [ $(uname -m) = "aarch64" ]; then echo aarch64; else echo x86_64; fi)
@@ -25,6 +37,9 @@ RUN chmod 755 /usr/local/bin/sendgrid-dev
 COPY supervisor/supervisord.conf /etc/supervisord.conf
 COPY supervisor/app.conf /etc/supervisor/conf.d/app.conf
 RUN echo files = /etc/supervisor/conf.d/*.conf >> /etc/supervisord.conf
+
+# remove temporary packages
+RUN apk del .temp-pkgs
 
 # Service to run
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN apk add --no-cache --virtual .temp-pkgs \
 WORKDIR ${APP_ROOT}
 
 # MailDev
+ENV MAILDEV_REPO_COMMIT_ID 96248f8c38bd269f541dd91e60ad560f57eb46a0
 RUN git clone https://github.com/maildev/maildev.git && \
     cd maildev && \
+    git reset --hard ${MAILDEV_REPO_COMMIT_ID} && \
     npm ci --only=production && \
     ln -fs ${APP_ROOT}/maildev/bin/maildev /usr/local/bin/maildev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,17 +16,14 @@ RUN apk update && \
 
 # install temporary packages
 RUN apk add --no-cache --virtual .temp-pkgs \
-    git \
-    python2 \
-    make \
-    g++
+    git
 
 WORKDIR ${APP_ROOT}
 
 # MailDev
 RUN git clone https://github.com/maildev/maildev.git && \
     cd maildev && \
-    npm ci --python=python2.7 && \
+    npm ci --only=production && \
     ln -fs ${APP_ROOT}/maildev/bin/maildev /usr/local/bin/maildev
 
 # sendgrid-dev


### PR DESCRIPTION
Hi. Thank you for creating the very useful package 👍 

I noticed that sendgrid-maildev is using the latest official release of MailDev v1.1.0 which is **released more than 2 years ago**.

The MailDev project seems not actively maintained for now so the official release has not been made for a while, BUT the repository code is still be updated by some contributors. 

This pull request changes to use the latest MailDev built from the repo code because I want to use some features that have been introduced after v1.1.0, such as configuring MailDev options via environment variables.

Thanks.
