### PR TITLE
Migrate MailDev from npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.18
 
 ENV APP_ROOT /var/www/html
 
@@ -15,15 +15,8 @@ RUN apk update && \
     nodejs \
     npm
 
-WORKDIR ${APP_ROOT}
-
 # MailDev
-ENV MAILDEV_REPO_COMMIT_ID 96248f8c38bd269f541dd91e60ad560f57eb46a0
-RUN git clone https://github.com/maildev/maildev.git && \
-    cd maildev && \
-    git reset --hard ${MAILDEV_REPO_COMMIT_ID} && \
-    npm ci --only=production && \
-    ln -fs ${APP_ROOT}/maildev/bin/maildev /usr/local/bin/maildev
+RUN npm install -g maildev
 
 # sendgrid-dev
 RUN curl -L -o /usr/local/bin/sendgrid-dev https://github.com/yKanazawa/sendgrid-dev/releases/download/v0.9.1/sendgrid-dev_$(if [ $(uname -m) = "aarch64" ]; then echo aarch64; else echo x86_64; fi)


### PR DESCRIPTION
Reference: Migrate MailDev built from the latest code
https://github.com/yKanazawa/sendgrid-maildev/pull/2

The latest Maildev is now provided by npm.
https://www.npmjs.com/package/maildev?activeTab=versions

So, update to the latest version with npm.

The newest version is 2.1.0
![image](https://github.com/yKanazawa/sendgrid-maildev/assets/6531126/edbfea7c-1f0e-4009-8ff5-9ed1aea1af48)
